### PR TITLE
Add compile to files removed by cleanup.

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -22,6 +22,7 @@ rm -f `cat <<EOF
     src/help.c
     src/qperf.1
     src/qperf
+    compile
 EOF`
 
 # We need to keep qperf.spec around for the OFED scripts but delete it if we do


### PR DESCRIPTION
Fixes #4 - cleanup does not remove compile script

This was previously opened by me and approved by Ira Weiny. The original pull request was closed when I moved commits off of my fork's master branch.