### PR TITLE
Include linux/types.h before rdma_cma.h.

### DIFF
--- a/src/rdma.c
+++ b/src/rdma.c
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <netinet/in.h>
+#include <linux/types.h>
 #include <rdma/rdma_cma.h>
 #include <infiniband/verbs.h>
 #include "qperf.h"


### PR DESCRIPTION
Fix Issue #8: fails to build on debian sid