### PR TITLE
Modernize configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT(qperf, 0.4.10, general@lists.openfabrics.org)
-AM_INIT_AUTOMAKE(qperf, 0.4.10)
+AM_INIT_AUTOMAKE
 AC_PROG_CC
 AC_CHECK_LIB(ibverbs, ibv_open_device, RDMA=1)
 AC_CHECK_LIB(ibverbs, ibv_open_xrc_domain, HAS_XRC=1)


### PR DESCRIPTION
  Fix Issue #9: configure.in needs modernization

  + Rename configure.in to configure.ac.
  + Use no-arg AC_INIT_AUTOMAKE.