### PR TITLE
Support for IPv6 address format in qperf tests

### DIFF
--- a/src/qperf.c
+++ b/src/qperf.c
@@ -62,7 +62,7 @@
  */
 #define VER_MAJ 0                       /* Major version */
 #define VER_MIN 4                       /* Minor version */
-#define VER_INC 11                       /* Incremental version */
+#define VER_INC 10                      /* Incremental version */
 #define LISTENQ 5                       /* Size of listen queue */
 #define BUFSIZE 1024                    /* Size of buffers */
 
@@ -1418,7 +1418,7 @@ server_listen(void)
     AI *ai;
     AI hints ={
         .ai_flags    = AI_PASSIVE | AI_NUMERICSERV,
-	.ai_family   = AF_INET6,
+        .ai_family   = AF_UNSPEC,
         .ai_socktype = SOCK_STREAM
     };
     AI *ailist = getaddrinfo_port(0, ListenPort, &hints);
@@ -1450,7 +1450,7 @@ static int
 server_recv_request(void)
 {
     socklen_t clientLen;
-    SS clientAddr;
+    struct sockaddr_in clientAddr;
 
     clientLen = sizeof(clientAddr);
     RemoteFD = accept(ListenFD, (struct sockaddr *)&clientAddr, &clientLen);

--- a/src/qperf.c
+++ b/src/qperf.c
@@ -62,7 +62,7 @@
  */
 #define VER_MAJ 0                       /* Major version */
 #define VER_MIN 4                       /* Minor version */
-#define VER_INC 10                      /* Incremental version */
+#define VER_INC 11                       /* Incremental version */
 #define LISTENQ 5                       /* Size of listen queue */
 #define BUFSIZE 1024                    /* Size of buffers */
 
@@ -1418,7 +1418,7 @@ server_listen(void)
     AI *ai;
     AI hints ={
         .ai_flags    = AI_PASSIVE | AI_NUMERICSERV,
-        .ai_family   = AF_UNSPEC,
+	.ai_family   = AF_INET6,
         .ai_socktype = SOCK_STREAM
     };
     AI *ailist = getaddrinfo_port(0, ListenPort, &hints);
@@ -1450,7 +1450,7 @@ static int
 server_recv_request(void)
 {
     socklen_t clientLen;
-    struct sockaddr_in clientAddr;
+    SS clientAddr;
 
     clientLen = sizeof(clientAddr);
     RemoteFD = accept(ListenFD, (struct sockaddr *)&clientAddr, &clientLen);

--- a/src/rds.c
+++ b/src/rds.c
@@ -43,8 +43,8 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <stdbool.h>
 #include "qperf.h"
-
 
 /*
  * Parameters.
@@ -107,7 +107,7 @@ static void     rds_makeaddr(SS *addr, socklen_t *len, char *host, int port);
 static void     set_parameters(long msgSize);
 static void     server_get_hosts(char *lhost, char *rhost);
 static void     set_socket_buffer_size(int fd);
-
+static inline bool  ipv6_addr_v4mapped(const struct in6_addr *a);
 
 /*
  * Static variables.
@@ -315,6 +315,15 @@ init(void)
 
 
 /*
+ * Check if it is IPv4-mapped IPv6 address
+ */
+static inline bool ipv6_addr_v4mapped(const struct in6_addr *a)
+{
+  return (a->s6_addr32[0] | a->s6_addr32[1] |
+          (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0;
+}
+
+/*
  * Have an exchange with the client over TCP/IP and get the IP of our local
  * host.
  */
@@ -323,34 +332,42 @@ server_get_hosts(char *lhost, char *rhost)
 {
     int fd, lfd;
     uint32_t port;
-    struct sockaddr_in laddr, raddr;
     socklen_t rlen;
+    struct sockaddr_in6 v6addr;
+    struct sockaddr_in v4addr;
+    SA *raddr;
 
-    lfd = socket(AF_INET, SOCK_STREAM, 0);
+    lfd = socket(AF_INET6, SOCK_STREAM, 0);
     if (lfd < 0)
         error(SYS, "socket failed");
     setsockopt_one(lfd, SO_REUSEADDR);
-
-    memset(&laddr, 0, sizeof(laddr));
-    laddr.sin_family = AF_INET;
-    laddr.sin_addr.s_addr = INADDR_ANY;
-    laddr.sin_port = htons(0);
-    if (bind(lfd, (SA *)&laddr, sizeof(laddr)) < 0)
-        error(SYS, "bind INET failed");
+    memset(&v6addr, 0, sizeof(v6addr));
+    v6addr.sin6_family = AF_INET6;
+    if (bind(lfd, (SA *)&v6addr, sizeof(v6addr)) < 0)
+          error(SYS, "bind INET6 failed");
 
     port = get_socket_port(lfd);
     encode_uint32(&port, port);
-    send_mesg(&port, sizeof(port), "TCP IPv4 server port");
-
+    send_mesg(&port, sizeof(port), "TCP server port");
     if (listen(lfd, 1) < 0)
         error(SYS, "listen failed");
 
-    rlen = sizeof(raddr);
-    fd = accept(lfd, (SA *)&raddr, &rlen);
+    rlen = sizeof(v6addr);
+    fd = accept(lfd, (SA *)&v6addr, &rlen);
     if (fd < 0)
         error(SYS, "accept failed");
     close(lfd);
-    get_socket_ip((SA *)&raddr, rlen, rhost, NI_MAXHOST);
+
+    if (ipv6_addr_v4mapped(&v6addr.sin6_addr)) {
+      v4addr.sin_family = AF_INET;
+      v4addr.sin_addr.s_addr = v6addr.sin6_addr.s6_addr32[3];
+      v4addr.sin_port = v6addr.sin6_port;
+      raddr = (SA *)&v4addr;
+      rlen = sizeof(v4addr);
+    } else {
+      raddr = (SA *)&v6addr;
+    }
+    get_socket_ip(raddr, rlen, rhost, NI_MAXHOST);
     send_mesg(rhost, NI_MAXHOST, "client IP");
     recv_mesg(lhost, NI_MAXHOST, "server IP");
     close(fd);
@@ -410,13 +427,30 @@ rds_socket(char *host, int port)
 static void
 rds_makeaddr(SS *addr, socklen_t *len, char *host, int port)
 {
+    int stat;
+    struct addrinfo *ailist;
     struct sockaddr_in *sap = (struct sockaddr_in *)addr;
+    struct sockaddr_in6 *sap6 = (struct sockaddr_in6 *)addr;
 
+    stat = getaddrinfo(host, NULL, NULL, &ailist);
+    if (stat != 0)
+        error(0, "getaddrinfo failed: %s", gai_strerror(stat));
+    switch (ailist->ai_family) {
+    case AF_INET:
     memset(sap, 0, sizeof(*sap));
-    sap->sin_family = AF_INET;
-    inet_pton(AF_INET, host, &sap->sin_addr.s_addr);
+          memcpy(addr, ailist->ai_addr, ailist->ai_addrlen);
     sap->sin_port = htons(port);
     *len = sizeof(struct sockaddr_in);
+          break;
+    case AF_INET6:
+	  memset(sap6, 0, sizeof(*sap6));
+	  memcpy(sap6, ailist->ai_addr, ailist->ai_addrlen);
+	  sap6->sin6_port = htons(port);
+          *len = sizeof(struct sockaddr_in6);
+          break;
+   default:
+	  error(0, "Unsupported Address family");
+   }
 }
 
 
@@ -431,7 +465,7 @@ connect_tcp(char *server, char *port, SS *addr, socklen_t *len, int *fd)
     struct addrinfo *aip, *ailist;
     struct addrinfo hints ={
         .ai_flags    = AI_NUMERICSERV,
-        .ai_family   = AF_INET,
+        .ai_family   = AF_UNSPEC,
         .ai_socktype = SOCK_STREAM
     };
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -699,10 +699,8 @@ getaddrinfo_kind(int serverflag, KIND kind, int port)
         .ai_socktype = SOCK_STREAM
     };
 
-    if (serverflag){
+    if (serverflag)
         hints.ai_flags |= AI_PASSIVE;
-        hints.ai_family = AF_INET6;
-    }	
     if (kind == K_UDP)
         hints.ai_socktype = SOCK_DGRAM;
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -699,8 +699,10 @@ getaddrinfo_kind(int serverflag, KIND kind, int port)
         .ai_socktype = SOCK_STREAM
     };
 
-    if (serverflag)
+    if (serverflag){
         hints.ai_flags |= AI_PASSIVE;
+        hints.ai_family = AF_INET6;
+    }	
     if (kind == K_UDP)
         hints.ai_socktype = SOCK_DGRAM;
 


### PR DESCRIPTION

Code changes so that qperf accepts both IPv4 and IPv6 addresses.