### PR TITLE
spec: build now requires running autogen script

### DIFF
--- a/qperf.spec.in
+++ b/qperf.spec.in
@@ -7,6 +7,7 @@ Group:          Networking/Diagnostic
 Source:         http://www.openfabrics.org/downloads/qperf/%{name}-%{version}.tar.gz
 Url:            http://www.openfabrics.org
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildRequires:  autoconf, automake
 @RDMA_TRUE@BuildRequires:  libibverbs-devel
 @RDMA_TRUE@BuildRequires:  librdmacm-devel
 
@@ -17,6 +18,7 @@ Measure socket and RDMA performance.
 %setup -q
 
 %build
+./autogen.sh
 %configure
 export CFLAGS="$RPM_OPT_FLAGS"
 %{__make}


### PR DESCRIPTION
This also requires extra build dependencies.

Note: if this and my other PR are applied, please also regenerate qperf.spec .

Signed-off-by: Tzafrir Cohen <tzafrirc@mellanox.com>