### PR TITLE
Fix 'make distcheck'

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,17 +11,18 @@ else
 AM_CFLAGS = -Wall -O
 qperf_SOURCES = qperf.c socket.c rds.c support.c help.c qperf.h
 endif
+EXTRA_DIST = help.txt mkman mkhelp
 
 man_MANS = qperf.1
 
-qperf.1: help.txt
-	./mkman >qperf.1
+qperf.1: $(srcdir)/help.txt
+	srcdir=$(srcdir) $(srcdir)/mkman >qperf.1
 
-help.c: help.txt
+help.c: $(srcdir)/help.txt
 if RDMA
-	./mkhelp RDMA
+	srcdir=$(srcdir) $(srcdir)/mkhelp RDMA
 else
-	./mkhelp
+	srcdir=$(srcdir) $(srcdir)/mkhelp
 endif
 
 clean-local:

--- a/src/mkhelp
+++ b/src/mkhelp
@@ -4,8 +4,13 @@ use strict;
 use warnings;
 use diagnostics;
 
-my $help_txt = "help.txt";
-my $help_c   = "help.c";
+my $src_dir = '.';
+if (exists $ENV{'srcdir'}) {
+	$src_dir = $ENV{'srcdir'};
+}
+
+my $help_txt = "$src_dir/help.txt";
+my $help_c   = "$src_dir/help.c";
 my $top = "
 /*
  * This was generated from $help_txt.  Do not modify directly.

--- a/src/mkman
+++ b/src/mkman
@@ -7,7 +7,12 @@ use diagnostics;
 use POSIX;
 
 
-my $help_txt  = "help.txt";
+my $src_dir = '.';
+if (exists $ENV{'srcdir'}) {
+	$src_dir = $ENV{'srcdir'};
+}
+
+my $help_txt  = "$src_dir/help.txt";
 
 
 # Print out an error message and exit.


### PR DESCRIPTION
Now 'make distcheck' works.

This mainly fixed separate build directory:

mkdir build_dir1
cd build_dir1
../configure
make # and make install, and whatever

Signed-off-by: Tzafrir Cohen <tzafrirc@mellanox.com>